### PR TITLE
build(compose): init docker-compose for production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# project
+letsencrypt
+
 # compiled output
 /dist
 /node_modules

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,23 +2,32 @@ version: "3.2"
 
 services:
   backend: 
+    image: node:8
+    container_name: open-reg-backend-dev
+    depends_on:
+      - db
+    restart: always
     volumes:
       - ./src:/app/src
-    command: ['yarn', 'start:dev']
+      - ./node_modules:/app/node_modules
+      - ./package.json:/app/package.json
+      - ./tsconfig.json:/app/tsconfig.json
+      - ./tsconfig.build.json:/app/tsconfig.build.json
     ports:
       - 3000:3000
     environment: 
       MONGO_URL: mongodb://db/open-reg
       SECRET: secret
       NODE_ENV: development
-    depends_on:
-      - db
+    working_dir: /app
+    command: ['yarn', 'start:dev']
+
   db:
+    image: mongo:4.2
     container_name: open-reg-db
-    image: mongo:4
     restart: always
-    ports:
-      - 27017:27017
     volumes: 
       - ./volumes/mongodb:/data/db
       - ./volumes/mongodb_config:/data/configdb
+    ports:
+      - 27017:27017

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,43 @@
+version: "3.2"
+
+services:
+  traefik:
+    image: 'traefik:v2.0.0'
+    container_name: 'traefik'
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https'
+
+      - 'traefik.http.routers.api.entrypoints=web'
+      - 'traefik.http.routers.api.rule=Host(`traefik.openreg.app`)'
+      - 'traefik.http.routers.api.service=api@internal'
+    command:
+      # - '--log.level=DEBUG'
+      # - '--api.insecure=true'
+      - '--api=true'
+      - '--providers.docker=true'
+      - '--providers.docker.exposedbydefault=false'
+      - '--entrypoints.web.address=:80'
+      - '--entrypoints.websecure.address=:443'
+      - '--certificatesresolvers.myhttpchallenge.acme.httpchallenge=true'
+      - '--certificatesresolvers.myhttpchallenge.acme.httpchallenge.entrypoint=web'
+      - '--certificatesresolvers.myhttpchallenge.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory'
+      - '--certificatesresolvers.myhttpchallenge.acme.email=ichannel.jakpat@gmail.com'
+      - '--certificatesresolvers.myhttpchallenge.acme.storage=/letsencrypt/acme.json'
+    ports:
+      - '80:80'
+      - '443:443'
+      - '8080:8080'
+    volumes:
+      - './letsencrypt:/letsencrypt'
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+
+  backend:
+    container_name: open-reg-backend-prod
+    build: .
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.backend.rule=Host(`api.openreg.app`)'
+      - 'traefik.http.routers.backend.entrypoints=websecure'
+      - 'traefik.http.routers.backend.tls.certresolver=myhttpchallenge'
+      - 'traefik.http.services.backend.loadbalancer.server.port=3000'

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -2,10 +2,11 @@ version: "3.2"
 
 services:
   backend:  
+    image: open-reg-backend
+    container_name: open-reg-backend-stagging
+    build: .
     ports:
       - ${PORT}:${PORT}
     environment: 
-      MONGO_URL:
-      SECRET:
       PORT: 
       NODE_ENV: staging

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -3,7 +3,7 @@ version: "3.2"
 services:
   backend:  
     image: open-reg-backend
-    container_name: open-reg-backend-stagging
+    container_name: open-reg-backend-staging
     build: .
     ports:
       - ${PORT}:${PORT}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,11 @@ version: "3.2"
 
 services:
   backend: 
-    build: .  
+    image: open-reg-backend
     container_name: open-reg-backend
-    restart: always
+    environment:
+      MONGO_URL:
+      SECRET:
+      NODE_ENV:
+      CHULA_APP_ID:
+      CHULA_APP_SECRET:


### PR DESCRIPTION
Changes:
- refactor docker-compose.yml to be more generic
- add docker-compose.prod.yml for production deployment
- use traefik as a reverse proxy and cert-manager
