### PR TITLE
fix(swagger): swagger-ui use HTTPS schema over HTTPS

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ async function bootstrap() {
     const options = new DocumentBuilder()
         .setTitle('Open Reg API')
         .setVersion('1.0')
+        .setSchemes('https', 'http')
         .build();
     const document = SwaggerModule.createDocument(app, options);
     SwaggerModule.setup('api', app, document);


### PR DESCRIPTION
When served over HTTPS, `swagger-ui` should prefer HTTPS API protocol

issue: https://github.com/swagger-api/swagger-ui/issues/2342
pr: https://github.com/swagger-api/swagger-js/pull/857